### PR TITLE
FPPSP-322 - Fix enter keypress events in all families/households search views

### DIFF
--- a/src/app/families/index/layout-view.js
+++ b/src/app/families/index/layout-view.js
@@ -82,8 +82,8 @@ export default Mn.View.extend({
     });
   },
   handleSubmit(event) {
-    event.preventDefault();
     if (event.which === 13 || event.which === 1) {
+      event.preventDefault();
       const self = this;
       const container = this.$el.find('.list-container').eq(0);
       const section = utils.getLoadingSection(container);

--- a/src/app/families/index/layout-view.js
+++ b/src/app/families/index/layout-view.js
@@ -1,11 +1,10 @@
 import Mn from 'backbone.marionette';
 import Bn from 'backbone';
 import $ from 'jquery';
-
 import Template from './layout-template.hbs';
 import CollectionView from './collection-view';
 import utils from '../../utils';
-import FamiliesColecction from '../collection';
+import FamiliesCollection from '../collection';
 import OrganizationsModel from '../../management/organizations/model';
 import CitiesModel from '../../cities/model';
 import CountiesModel from '../../countries/model';
@@ -33,6 +32,14 @@ export default Mn.View.extend({
     }, 0);
     this.showList();
 
+    this.loadSelects();
+  },
+  showList() {
+    this.getRegion('list').show(
+      new CollectionView({collection: this.collection})
+    );
+  },
+  loadSelects() {
     const self = this;
 
     this.citiesCollection.fetch({
@@ -71,20 +78,11 @@ export default Mn.View.extend({
               .text(element.name)
           );
         });
-
-        // if (!(session.userHasRole('ROLE_ROOT') || session.userHasRole('ROLE_HUB_ADMIN'))) {
-        //   $('#organization').attr('disabled', 'true');
-        //   $('#organization').val(session.get('user').organization.id);
-        // }
       }
     });
   },
-  showList() {
-    this.getRegion('list').show(
-      new CollectionView({ collection: this.collection })
-    );
-  },
   handleSubmit(event) {
+    event.preventDefault();
     if (event.which === 13 || event.which === 1) {
       const self = this;
       const container = this.$el.find('.list-container').eq(0);
@@ -101,7 +99,7 @@ export default Mn.View.extend({
         free_text: $('#search').val()
       };
 
-      const elements = new FamiliesColecction();
+      const elements = new FamiliesCollection();
       elements.fetch({
         data: params,
         success(response) {

--- a/src/app/families/user/view.js
+++ b/src/app/families/user/view.js
@@ -32,8 +32,8 @@ export default Mn.View.extend({
     );
   },
   handleSubmit(event) {
-    event.preventDefault();
     if (event.which === 13 || event.which === 1) {
+      event.preventDefault();
       const self = this;
       const container = this.$el.find('.list-container').eq(0);
       const section = utils.getLoadingSection(container);

--- a/src/app/families/user/view.js
+++ b/src/app/families/user/view.js
@@ -1,12 +1,10 @@
 import Mn from 'backbone.marionette';
 import Bn from 'backbone';
 import $ from 'jquery';
-
 import Template from './template.hbs';
 import CollectionView from '../index/collection-view';
 import utils from '../../utils';
-import FamiliesColecction from './collection';
-
+import FamiliesCollection from './collection';
 
 export default Mn.View.extend({
   template: Template,
@@ -27,14 +25,14 @@ export default Mn.View.extend({
       this.$el.find('#search').focus();
     }, 0);
     this.showList();
-
   },
   showList() {
     this.getRegion('list').show(
-      new CollectionView({ collection: this.collection })
+      new CollectionView({collection: this.collection})
     );
   },
   handleSubmit(event) {
+    event.preventDefault();
     if (event.which === 13 || event.which === 1) {
       const self = this;
       const container = this.$el.find('.list-container').eq(0);
@@ -44,14 +42,7 @@ export default Mn.View.extend({
       this.getRegion('list').empty();
       section.loading();
 
-      // const params = {
-      //   organization_id: $('#organization').val(),
-      //   country_id: $('#country').val(),
-      //   city_id: $('#city').val(),
-      //   free_text: $('#search').val()
-      // };
-
-      const elements = new FamiliesColecction();
+      const elements = new FamiliesCollection();
       elements.fetch({
         data: {name: $('#search').val()},
         success(response) {

--- a/src/app/management/organizations/show/families/index/layout-view.js
+++ b/src/app/management/organizations/show/families/index/layout-view.js
@@ -87,8 +87,8 @@ export default Mn.View.extend({
     );
   },
   handleSubmit(event) {
-    event.preventDefault();
     if (event.which === 13 || event.which === 1) {
+      event.preventDefault();
       let container = this.$el.find('.list-container').eq(0);
       const section = utils.getLoadingSection(container);
 

--- a/src/app/management/organizations/show/families/index/layout-view.js
+++ b/src/app/management/organizations/show/families/index/layout-view.js
@@ -89,11 +89,10 @@ export default Mn.View.extend({
   handleSubmit(event) {
     event.preventDefault();
     if (event.which === 13 || event.which === 1) {
-      let self = this;
       let container = this.$el.find('.list-container').eq(0);
       const section = utils.getLoadingSection(container);
 
-      self.collection.reset();
+      this.collection.reset();
       this.getRegion('list').empty();
       section.loading();
 
@@ -104,6 +103,7 @@ export default Mn.View.extend({
         free_text: $('#search').val()
       };
 
+      let self = this;
       let elements = new FamiliesCollection();
       elements.fetch({
         data: params,

--- a/src/app/management/organizations/show/families/index/layout-view.js
+++ b/src/app/management/organizations/show/families/index/layout-view.js
@@ -1,11 +1,10 @@
 import Mn from 'backbone.marionette';
 import $ from 'jquery';
 import Bn from 'backbone';
-
 import Template from '../../../../../families/index/layout-template.hbs';
 import CollectionView from '../../../../../families/index/collection-view';
 import utils from '../../../../../utils';
-import FamiliesColecction from '../../../../../families/collection';
+import FamiliesCollection from '../../../../../families/collection';
 import OrganizationsModel from '../../../../organizations/model';
 import CitiesModel from '../../../../../cities/model';
 import CountiesModel from '../../../../../countries/model';
@@ -20,14 +19,15 @@ export default Mn.View.extend({
     list: '#family-list'
   },
   events: {
-    'click #submit': 'handleSubmit'
+    'click #submit': 'handleSubmit',
+    'keypress #search': 'handleSubmit'
   },
   initialize(options) {
     this.collection = new Bn.Collection();
     this.organizationId = options.organizationId;
   },
   onRender() {
-    let { organizationId } = this;
+    let {organizationId} = this;
     setTimeout(() => {
       this.$el.find('#search').focus();
     }, 0);
@@ -83,34 +83,37 @@ export default Mn.View.extend({
   },
   showList() {
     this.getRegion('list').show(
-      new CollectionView({ collection: this.collection })
+      new CollectionView({collection: this.collection})
     );
   },
-  handleSubmit() {
-    var self = this;
-    let container = this.$el.find('.list-container').eq(0);
-    const section = utils.getLoadingSection(container);
+  handleSubmit(event) {
+    event.preventDefault();
+    if (event.which === 13 || event.which === 1) {
+      let self = this;
+      let container = this.$el.find('.list-container').eq(0);
+      const section = utils.getLoadingSection(container);
 
-    self.collection.reset();
-    this.getRegion('list').empty();
-    section.loading();
+      self.collection.reset();
+      this.getRegion('list').empty();
+      section.loading();
 
-    let params = {
-      organization_id: $('#organization').val(),
-      country_id: $('#country').val(),
-      city_id: $('#city').val(),
-      free_text: $('#search').val()
-    };
+      let params = {
+        organization_id: $('#organization').val(),
+        country_id: $('#country').val(),
+        city_id: $('#city').val(),
+        free_text: $('#search').val()
+      };
 
-    let elements = new FamiliesColecction();
-    elements.fetch({
-      data: params,
-      success(response) {
-        // setear al collection
-        self.collection = response;
-        self.showList();
-        section.reset();
-      }
-    });
+      let elements = new FamiliesCollection();
+      elements.fetch({
+        data: params,
+        success(response) {
+          // setear al collection
+          self.collection = response;
+          self.showList();
+          section.reset();
+        }
+      });
+    }
   }
 });


### PR DESCRIPTION
[FPPSP-322](http://jira.fundacionparaguaya.org.py/browse/FPPSP-322) - Fix enter keypress events in all families/households search views

In certain cases (logged as Root, Hub Admin, App Admin) in the search families view an `Enter` keypress triggers a page reload and the search only happens the second time the key is pressed. 
Page reload has been fixed and search now works on the first keypress.