### PR TITLE
Fix missing 'No indicator selected' message for indicators with no default

### DIFF
--- a/src/static/i18n/en_GB.json
+++ b/src/static/i18n/en_GB.json
@@ -67,6 +67,7 @@
     "economic-info": "Socio-economic Information",
     "indicators": "Indicators",
     "not-answer": "Skip question",
+    "select-an-option": "Select an option for this Indicator",
     "buttons": {
       "save-draft": "Save Draft"
     },

--- a/src/static/i18n/en_US.json
+++ b/src/static/i18n/en_US.json
@@ -67,6 +67,7 @@
     "economic-info": "Socio-economic Information",
     "indicators": "Indicators",
     "not-answer": "Skip question",
+    "select-an-option": "Select an option for this Indicator",
     "buttons": {
       "save-draft": "Save Draft"
     },

--- a/src/static/i18n/es_PY.json
+++ b/src/static/i18n/es_PY.json
@@ -67,6 +67,7 @@
     "economic-info": "Información Socioeconómica",
     "indicators": "Indicadores",
     "not-answer": "Omitir pregunta",
+    "select-an-option": "Selecciona una opción para este Indicador",
     "buttons": {
       "save-draft": "Guardar Borrador"
     },


### PR DESCRIPTION
When indicators are defined without a default value selected in the survey definition, there is a message displayed if you don't select an option and try to move next, this message was broken/missing. This PR adds this message and fix this bug.